### PR TITLE
Modified IPC to compute dynamically the Independent Subgraph

### DIFF
--- a/include/ipc/consensus.hpp
+++ b/include/ipc/consensus.hpp
@@ -11,20 +11,19 @@ public :
 
     bool agreementCheck(EDGE* loop_candidate);
     bool removeEdgeFromCnS(EDGE* edge);
-    bool addEdgeToCnS(EDGE* edge);
+    void addEdgeToCnS(EDGE* edge);
 
-    const std::vector<std::pair<int, int>>& getMaxConsensusSet() const { return _max_consensus_set; }
-    const std::vector<std::pair<int, int>>& getClusters() const { return _clusters; }
+    const std::vector<EDGE*>& getMaxConsensusSet() const { return _max_consensus_set; }
 
 private :
 
+    std::pair<int, int> computeIndependentSubgraph(const EDGE& edge_candidate,
+                                                   g2o::OptimizableGraph::EdgeSet& eset_independent);
+
     g2o::SparseOptimizer* _problem;
 
-    std::vector<std::pair<int, int>> _max_consensus_set;
-    std::vector<std::pair<int, int>> _clusters;
+    std::vector<EDGE*> _max_consensus_set; 
     std::vector<EDGE*> _odom_edges;
-    std::vector<g2o::OptimizableGraph::EdgeSet> _edgesxcl;
-    std::vector<g2o::OptimizableGraph::EdgeSet> _edgesxcl_only_loops;
 
     double _fast_reject_th;
     int _fast_reject_iter_base;

--- a/include/ipc/utils.hpp
+++ b/include/ipc/utils.hpp
@@ -106,6 +106,7 @@ bool cmpFirst(std::pair<int, int> p1, std::pair<int, int> p2);
 bool cmpSecond(std::pair<int, int> p1, std::pair<int, int> p2);
 bool cmpEdgesID(g2o::OptimizableGraph::Edge* e1, 
                 g2o::OptimizableGraph::Edge* e2);
+bool cmpEdgesTime(g2o::OptimizableGraph::Edge* e1, g2o::OptimizableGraph::Edge* e2);
 bool cmpScores(std::pair<double, g2o::OptimizableGraph::Edge*> p1, 
                std::pair<double, g2o::OptimizableGraph::Edge*> p2);
 bool cmpTime(std::pair<int, g2o::OptimizableGraph::Edge*> p1, 

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -80,14 +80,9 @@ void simulating_incremental_data(const Config& cfg,
     float precision = tp / (float)(tp + fp);
     float recall = tp / (float)(tp + fn);
 
-    const vector<pair<int, int>> clusters = ipc.getClusters();
-    const vector<pair<int, int>> max_consensus_set = ipc.getMaxConsensusSet();
-
-    for ( size_t counter = 0 ; counter < clusters.size() ; ++counter )    
-        cout << "L("<< counter << ") = [" << clusters[counter].first << ", " << clusters[counter].second << "]\n";
-    int size_max_consensus = 0;
-    for ( size_t counter = 0 ; counter < gt_loops.size() ; size_max_consensus += bucket[counter++] );
-    cout << "Size of MAX consistent set = " << size_max_consensus << endl;
+    //const vector<pair<int, int>> clusters = ipc.getClusters();
+    const vector<EDGE*> max_consensus_set = ipc.getMaxConsensusSet();
+    cout << "Size of MAX consistent set = " << max_consensus_set.size() << endl;
 
     cout << "Avg Time x test = " << avg_time / tot_hypothesis << " [s]\n";
     cout << "Precision = " << precision << endl;        

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -368,6 +368,14 @@ bool cmpEdgesID(OptimizableGraph::Edge* e1, OptimizableGraph::Edge* e2)
     return (e1->vertices()[1]->id() < e2->vertices()[1]->id());
 }
 
+bool cmpEdgesTime(OptimizableGraph::Edge* e1, OptimizableGraph::Edge* e2)
+{
+    int v1_end = max(e1->vertices()[0]->id(), e1->vertices()[1]->id());
+    int v2_end = max(e2->vertices()[0]->id(), e2->vertices()[1]->id());
+
+    return (v1_end < v2_end);
+}
+
 bool cmpTime(pair<int, OptimizableGraph::Edge*> p1, pair<int, OptimizableGraph::Edge*> p2)
 {
     int id1_v1 = p1.second->vertices()[1]->id();


### PR DESCRIPTION
It computes dynamically the Independent Subgraph instead of relyng on the incrementally computed clusters. Memory footprint reduced, code readability improved. Also the speed benefits for smaller sized problems.